### PR TITLE
git commit -m "fix: Correct line counting in diff generation

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -885,10 +885,7 @@ func buildUnifiedDiff(oldText, newText string) (string, int, int) {
 }
 
 func countLines(text string) int {
-	if text == "" {
-		return 0
-	}
-	return len(strings.Split(text, "\n"))
+	return strings.Count(text, "\n")
 }
 
 // corsMiddleware wraps an HTTP handler with CORS headers


### PR DESCRIPTION
- Change countLines() to use strings.Count() instead of Split()
- Fixes issue where diffs always showed +1/-1 regardless of size
- Now accurately counts newlines for added/removed line metrics"